### PR TITLE
Add Nuxt site for laptop catalog with markdown generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.nuxt

--- a/content/laptops/0-hp-15s-fq5007tu.md
+++ b/content/laptops/0-hp-15s-fq5007tu.md
@@ -1,0 +1,15 @@
+---
+brand: "HP"
+model: "15s-fq5007TU"
+processor: "Core i3"
+operatingSystem: "Windows 11 Home"
+storageMB: 512
+ramGB: 8
+screenSize: 39.62
+touchScreen: false
+price: 467.88
+---
+
+# HP 15s-fq5007TU
+
+Detalles del equipo HP 15s-fq5007TU.

--- a/content/laptops/1-hp-15s-fy5003tu.md
+++ b/content/laptops/1-hp-15s-fy5003tu.md
@@ -1,0 +1,15 @@
+---
+brand: "HP"
+model: "15s-fy5003TU"
+processor: "Core i3"
+operatingSystem: "Windows 11 Home"
+storageMB: 512
+ramGB: 8
+screenSize: 39.62
+touchScreen: false
+price: 455.88
+---
+
+# HP 15s-fy5003TU
+
+Detalles del equipo HP 15s-fy5003TU.

--- a/content/laptops/2-apple-2020-macbook-air.md
+++ b/content/laptops/2-apple-2020-macbook-air.md
@@ -1,0 +1,15 @@
+---
+brand: "Apple"
+model: "2020 Macbook Air"
+processor: "M1"
+operatingSystem: "Mac OS Big Sur"
+storageMB: 256
+ramGB: 8
+screenSize: 33.78
+touchScreen: false
+price: 851.88
+---
+
+# Apple 2020 Macbook Air
+
+Detalles del equipo Apple 2020 Macbook Air.

--- a/content/laptops/3-apple-2020-macbook-air.md
+++ b/content/laptops/3-apple-2020-macbook-air.md
@@ -1,0 +1,15 @@
+---
+brand: "Apple"
+model: "2020 Macbook Air"
+processor: "M1"
+operatingSystem: "Mac OS Big Sur"
+storageMB: 256
+ramGB: 8
+screenSize: 33.78
+touchScreen: false
+price: 851.88
+---
+
+# Apple 2020 Macbook Air
+
+Detalles del equipo Apple 2020 Macbook Air.

--- a/data/laptops.csv
+++ b/data/laptops.csv
@@ -1,0 +1,5 @@
+Num,Brand,Model_Name,Processor,Operating_System,Storage_MB,RAM_GB,Screen_Size,Touch_Screen,Price
+0,HP,15s-fq5007TU,Core i3,Windows 11 Home,512,8,39.62,No,467.88
+1,HP,15s-fy5003TU,Core i3,Windows 11 Home,512,8,39.62,No,455.88
+2,Apple,2020 Macbook Air,M1,Mac OS Big Sur,256,8,33.78,No,851.88
+3,Apple,2020 Macbook Air,M1,Mac OS Big Sur,256,8,33.78,No,851.88

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,10 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/content'
+  ],
+  content: {
+    documentDriven: false
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "laptop-catalog",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate"
+  },
+  "dependencies": {
+    "nuxt": "^3.11.0",
+    "@nuxt/content": "^2.8.1"
+  }
+}

--- a/pages/[category]/[value].vue
+++ b/pages/[category]/[value].vue
@@ -1,0 +1,32 @@
+<script setup>
+import { useRoute } from 'vue-router'
+import { queryContent } from '#content'
+
+const route = useRoute()
+const { category, value } = route.params
+
+const categories = {
+  brand: { field: 'brand', title: 'Marca' },
+  operatingSystem: { field: 'operatingSystem', title: 'Sistema Operativo' },
+  screenSize: { field: 'screenSize', title: 'Tamaño de pantalla' },
+  processor: { field: 'processor', title: 'Procesador' }
+}
+
+const meta = categories[category]
+if (!meta) {
+  throw createError({ statusCode: 404, statusMessage: 'Categoría no válida' })
+}
+
+const laptops = await queryContent('laptops').where({ [meta.field]: value }).find()
+</script>
+
+<template>
+  <div>
+    <h2>{{ meta.title }}: {{ value }}</h2>
+    <ul>
+      <li v-for="lap in laptops" :key="lap._path">
+        <NuxtLink :to="lap._path">{{ lap.model }}</NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/pages/[category]/index.vue
+++ b/pages/[category]/index.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { useRoute } from 'vue-router'
+import { queryContent } from '#content'
+
+const route = useRoute()
+const category = route.params.category
+
+const categories = {
+  brand: { field: 'brand', title: 'Marca' },
+  operatingSystem: { field: 'operatingSystem', title: 'Sistema Operativo' },
+  screenSize: { field: 'screenSize', title: 'Tamaño de pantalla' },
+  processor: { field: 'processor', title: 'Procesador' }
+}
+
+const meta = categories[category]
+if (!meta) {
+  throw createError({ statusCode: 404, statusMessage: 'Categoría no válida' })
+}
+
+const { data } = await queryContent('laptops').find()
+const values = Array.from(new Set(data.map(item => item[meta.field]))).sort()
+</script>
+
+<template>
+  <div>
+    <h2>{{ meta.title }}</h2>
+    <ul>
+      <li v-for="val in values" :key="val">
+        <NuxtLink :to="`/${category}/${encodeURIComponent(val)}`">{{ val }}</NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <h1>Catálogo de Laptops</h1>
+    <ul>
+      <li><NuxtLink to="/brand">Marca</NuxtLink></li>
+      <li><NuxtLink to="/operatingSystem">Sistema Operativo</NuxtLink></li>
+      <li><NuxtLink to="/screenSize">Tamaño de pantalla</NuxtLink></li>
+      <li><NuxtLink to="/processor">Procesador</NuxtLink></li>
+    </ul>
+  </div>
+</template>

--- a/pages/laptops/[...slug].vue
+++ b/pages/laptops/[...slug].vue
@@ -1,0 +1,16 @@
+<script setup>
+import { useRoute } from 'vue-router'
+import { queryContent } from '#content'
+
+const route = useRoute()
+const slug = route.params.slug
+const path = Array.isArray(slug) ? slug.join('/') : slug
+
+const doc = await queryContent(`laptops/${path}`).findOne()
+</script>
+
+<template>
+  <div>
+    <ContentDoc :document="doc" />
+  </div>
+</template>

--- a/scripts/generateMarkdown.js
+++ b/scripts/generateMarkdown.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const csvPath = path.join(__dirname, '..', 'data', 'laptops.csv');
+const outDir = path.join(__dirname, '..', 'content', 'laptops');
+
+const csv = fs.readFileSync(csvPath, 'utf-8').trim();
+const lines = csv.split(/\r?\n/);
+const headers = lines.shift().split(',');
+
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+lines.forEach((line, idx) => {
+  if (!line.trim()) return;
+  const cols = line.split(',');
+  const row = {};
+  headers.forEach((h, i) => row[h] = cols[i]);
+
+  const slugBase = `${row.Brand}-${row.Model_Name}`.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const slug = `${row.Num}-${slugBase}`;
+
+  const frontMatter = `---\nbrand: "${row.Brand}"\nmodel: "${row.Model_Name}"\nprocessor: "${row.Processor}"\noperatingSystem: "${row.Operating_System}"\nstorageMB: ${row.Storage_MB}\nramGB: ${row.RAM_GB}\nscreenSize: ${row.Screen_Size}\ntouchScreen: ${row.Touch_Screen === 'Yes'}\nprice: ${row.Price}\n---\n`;
+
+  const content = `# ${row.Brand} ${row.Model_Name}\n\nDetalles del equipo ${row.Brand} ${row.Model_Name}.`;
+
+  fs.writeFileSync(path.join(outDir, `${slug}.md`), frontMatter + '\n' + content);
+});
+
+console.log('Markdown files generated in', outDir);


### PR DESCRIPTION
## Summary
- add script to convert `laptops.csv` into markdown pages with YAML front matter
- configure Nuxt 3 site with content module
- implement navigation to filter laptops by brand, OS, screen size or processor

## Testing
- `node scripts/generateMarkdown.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba1f7d52048333a3bc6c9e1b08cb13