### PR TITLE
docs: add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # arquitecturaInformacion
-tareas
+
+Nuxt 3 application that displays a catalog of laptops. Laptop details are stored as Markdown in `content/laptops` and can be regenerated from the CSV dataset in `data/laptops.csv` using the provided script.
+
+## Getting Started
+
+1. **Install dependencies**
+   
+   ```bash
+   npm install
+   ```
+
+2. **Run the development server**
+   
+   ```bash
+   npm run dev
+   ```
+   
+   The site will be available at http://localhost:3000.
+
+3. **Build for production**
+
+   ```bash
+   npm run build
+   ```
+
+4. **Generate static site**
+
+   ```bash
+   npm run generate
+   ```
+
+## Updating laptop content
+
+If you change `data/laptops.csv`, regenerate the Markdown files with:
+
+```bash
+node scripts/generateMarkdown.js
+```
+
+This creates files under `content/laptops/`.


### PR DESCRIPTION
## Summary
- document setup and usage instructions
- note script for regenerating laptop markdown from CSV

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba2950f2f083338a02f03191e3144d