### PR TITLE
Display laptop data from Markdown content

### DIFF
--- a/pages/[category]/[value].vue
+++ b/pages/[category]/[value].vue
@@ -1,6 +1,5 @@
 <script setup>
 import { useRoute } from 'vue-router'
-import { queryContent } from '#content'
 
 const route = useRoute()
 const { category, value } = route.params
@@ -17,7 +16,7 @@ if (!meta) {
   throw createError({ statusCode: 404, statusMessage: 'Categoría no válida' })
 }
 
-const laptops = await queryContent('laptops').where({ [meta.field]: value }).find()
+const laptops = await queryContent('laptops').where({ [meta.field]: value, _extension: 'md' }).find()
 </script>
 
 <template>

--- a/pages/[category]/index.vue
+++ b/pages/[category]/index.vue
@@ -1,6 +1,5 @@
 <script setup>
 import { useRoute } from 'vue-router'
-import { queryContent } from '#content'
 
 const route = useRoute()
 const category = route.params.category
@@ -17,8 +16,8 @@ if (!meta) {
   throw createError({ statusCode: 404, statusMessage: 'Categoría no válida' })
 }
 
-const { data } = await queryContent('laptops').find()
-const values = Array.from(new Set(data.map(item => item[meta.field]))).sort()
+const laptops = await queryContent('laptops').where({ _extension: 'md' }).find()
+const values = Array.from(new Set(laptops.map(item => item[meta.field]))).sort()
 </script>
 
 <template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,25 +1,13 @@
-<script setup lang="ts">
-const route = useRoute()
-
-// Get the single CSV document
-const doc = await queryContent('laptops').findOne()
-
-// For CSV, rows are in `doc.body`
-const rows = doc?.body || []
-
-// Expect a `category` column in the CSV to match the route param
-const list = computed(() =>
-  rows.filter((r: any) => (r.category || '').toLowerCase() === String(route.params.category).toLowerCase())
-)
+<script setup>
+const laptops = await queryContent('laptops').where({ _extension: 'md' }).find()
 </script>
 
 <template>
   <section>
-    <h1>Catálogo de {{ route.params.category }}</h1>
+    <h1>Catálogo de Laptops</h1>
     <ul>
-      <li v-for="(item, i) in list" :key="i">
-        <NuxtLink :to="`/laptops/${item.slug}`">{{ item.Marca }} {{ item.Modelo }}</NuxtLink>
-        — {{ item['Sistema Operativo'] }}
+      <li v-for="lap in laptops" :key="lap._path">
+        <NuxtLink :to="lap._path">{{ lap.brand }} {{ lap.model }}</NuxtLink>
       </li>
     </ul>
   </section>

--- a/pages/laptops/[...slug].vue
+++ b/pages/laptops/[...slug].vue
@@ -1,16 +1,16 @@
-<script setup lang="ts">
+<script setup>
 const route = useRoute()
-const doc = await queryContent('laptops').findOne()
-const rows = doc?.body || []
-const item = computed(() => rows.find((r: any) => String(r.slug) === String(route.params.slug)))
+const slug = Array.isArray(route.params.slug) ? route.params.slug.join('/') : route.params.slug
+const item = await queryContent('laptops/' + slug).findOne()
 </script>
 
 <template>
   <article v-if="item">
-    <h1>{{ item.Marca }} {{ item.Modelo }}</h1>
-    <p>Sistema Operativo: {{ item['Sistema Operativo'] }}</p>
-    <p>Tamaño de pantalla: {{ item['Tamaño de pantalla'] }}</p>
-    <p>Procesador: {{ item.Procesador }}</p>
+    <h1>{{ item.brand }} {{ item.model }}</h1>
+    <p>Sistema Operativo: {{ item.operatingSystem }}</p>
+    <p>Tamaño de pantalla: {{ item.screenSize }}</p>
+    <p>Procesador: {{ item.processor }}</p>
+    <ContentRenderer :value="item" />
   </article>
   <p v-else>No encontrado.</p>
 </template>


### PR DESCRIPTION
## Summary
- Load catalog data directly from markdown files and list all laptops on the home page
- Filter categories and values using YAML front‑matter fields
- Show laptop details from markdown front matter and render markdown body

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba35262f9c83339726c277e6d7ce58