### PR TITLE
feat: read laptops from tarea2 directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # arquitecturaInformacion
 
-Nuxt 3 application that displays a catalog of laptops. Laptop details are stored as Markdown in `content/laptops` and can be regenerated from the CSV dataset in `data/laptops.csv` using the provided script.
+Nuxt 3 application that displays a catalog of laptops. Laptop details are stored as Markdown in `content/tarea2/laptops` and can be regenerated from the CSV dataset in `data/laptops.csv` using the provided script.
 
 ## Getting Started
 
@@ -38,4 +38,4 @@ If you change `data/laptops.csv`, regenerate the Markdown files with:
 node scripts/generateMarkdown.js
 ```
 
-This creates files under `content/laptops/`.
+This creates files under `content/tarea2/laptops/`.

--- a/content/tarea2/laptops/pcs.md
+++ b/content/tarea2/laptops/pcs.md
@@ -1,0 +1,15 @@
+---
+brand: "Dell"
+model: "Inspiron 15"
+processor: "Core i5"
+operatingSystem: "Windows 11 Home"
+storageMB: 512
+ramGB: 8
+screenSize: 15.6
+touchScreen: false
+price: 699.99
+---
+
+# Dell Inspiron 15
+
+Detalles del equipo Dell Inspiron 15.

--- a/pages/[category]/[value].vue
+++ b/pages/[category]/[value].vue
@@ -16,7 +16,7 @@ if (!meta) {
   throw createError({ statusCode: 404, statusMessage: 'Categoría no válida' })
 }
 
-const laptops = await queryContent('laptops').where({ [meta.field]: value, _extension: 'md' }).find()
+const laptops = await queryContent('tarea2/laptops').where({ [meta.field]: value, _extension: 'md' }).find()
 </script>
 
 <template>

--- a/pages/[category]/index.vue
+++ b/pages/[category]/index.vue
@@ -16,7 +16,7 @@ if (!meta) {
   throw createError({ statusCode: 404, statusMessage: 'Categoría no válida' })
 }
 
-const laptops = await queryContent('laptops').where({ _extension: 'md' }).find()
+const laptops = await queryContent('tarea2/laptops').where({ _extension: 'md' }).find()
 const values = Array.from(new Set(laptops.map(item => item[meta.field]))).sort()
 </script>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-const laptops = await queryContent('laptops').where({ _extension: 'md' }).find()
+const laptops = await queryContent('tarea2/laptops').where({ _extension: 'md' }).find()
 </script>
 
 <template>

--- a/pages/tarea2/laptops/[...slug].vue
+++ b/pages/tarea2/laptops/[...slug].vue
@@ -1,0 +1,16 @@
+<script setup>
+const route = useRoute()
+const slug = Array.isArray(route.params.slug) ? route.params.slug.join('/') : route.params.slug
+const item = await queryContent('tarea2/laptops/' + slug).findOne()
+</script>
+
+<template>
+  <article v-if="item">
+    <h1>{{ item.brand }} {{ item.model }}</h1>
+    <p>Sistema Operativo: {{ item.operatingSystem }}</p>
+    <p>Tamaño de pantalla: {{ item.screenSize }}</p>
+    <p>Procesador: {{ item.processor }}</p>
+    <ContentRenderer :value="item" />
+  </article>
+  <p v-else>No encontrado.</p>
+</template>

--- a/scripts/generateMarkdown.js
+++ b/scripts/generateMarkdown.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const csvPath = path.join(__dirname, '..', 'data', 'laptops.csv');
-const outDir = path.join(__dirname, '..', 'content', 'laptops');
+const outDir = path.join(__dirname, '..', 'content', 'tarea2', 'laptops');
 
 const csv = fs.readFileSync(csvPath, 'utf-8').trim();
 const lines = csv.split(/\r?\n/);


### PR DESCRIPTION
## Summary
- display laptop catalog from `content/tarea2/laptops`
- add dynamic page for new laptop paths
- update markdown generator and documentation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba381e93b48333bc3b1cc75c19db5e